### PR TITLE
Remove ruby from packages

### DIFF
--- a/packages/cflinuxfs4
+++ b/packages/cflinuxfs4
@@ -165,7 +165,6 @@ openssl
 psmisc
 quota
 rsync
-ruby
 sshfs
 strace
 subversion


### PR DESCRIPTION
This PR is based off of the [`remove-python` branch](https://github.com/cloudfoundry/cflinuxfs4/tree/remove-python), so those changes also appear here. Let's merge #2 in before this PR.

Remove Ruby from the stack to reduce the CVE surface area of the image. Work has been done in the Java Buildpack to remove reliance on a stack-provided Ruby installation.

Packages removed:
- `ruby`

Packages added:
- none

Packages in the final receipt that were removed as a result of these changes:
- `libruby3.0:amd64`
- `rake`
- `ruby`
- `ruby-net-telnet`
- `ruby-rubygems`
- `ruby-webrick`
- `ruby-xmlrpc`
- `ruby3.0`
- `rubygems-integration`