### PR TITLE
Remove lsb-release, because it requires python3

### DIFF
--- a/packages/cflinuxfs4
+++ b/packages/cflinuxfs4
@@ -153,7 +153,6 @@ libyaml-dev
 locales
 lockfile-progs
 logrotate
-lsb-release
 lsof
 lzma
 manpages-dev


### PR DESCRIPTION
I believe the addition of `lsb-release` in #4 caused us to re-install `python3` in the image (https://github.com/cloudfoundry/cflinuxfs4/blob/1.0.0/receipt.cflinuxfs4.x86_64#L562-L565).

This PR removes `lsb-release`, which appears was re-added to fix our [failing tests](https://buildpacks.ci.cf-app.com/teams/core-deps/pipelines/cflinuxfs4/jobs/test/builds/69)

I have updated the tests and the cflinuxfs4 Go Buildpack code in the following PRs to accommodate for this removal:
- https://github.com/cloudfoundry/go-buildpack/pull/357 
- https://github.com/cloudfoundry/core-deps-ci/pull/39

As long as we're not specifically relying on `lsb-release` anywhere else, this should succeed in CI. From [a quick search](https://github.com/search?q=org%3Acloudfoundry++lsb_release&type=code), I see `lsb_release` commands are called in a number of places in cloudfoundry org (particularly in the Java BP), but I don't know enough about how all of the different bits of CF come together to understand if the lack of `lsb-release` in the stack will affect anything.

