### PR TITLE
Add support for cflinuxfs4 compat stack

### DIFF
--- a/.github/workflows/create-compat-stack.yml
+++ b/.github/workflows/create-compat-stack.yml
@@ -1,0 +1,54 @@
+name: Send dispatch for cflinuxfs4-compat release creation
+
+on:
+  release:
+    types:
+    - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version of the cflinuxfs4 stack release a compat stack of (e.g. 1.2.3)'
+        required: true
+
+jobs:
+  dispatch:
+    name: Send dispatch for compat stack creation
+    runs-on: ubuntu-22.04
+    steps:
+
+    - name: Parse Event
+      id: event
+      run: |
+        version="${{ github.event.inputs.version }}"
+        if [ -z "${version}" ]; then
+          version="$(jq -r '.release.tag_name' "${GITHUB_EVENT_PATH}" | sed s/^v//)"
+        fi
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repository: cloudfoundry/cflinuxfs4-compat-release
+        event-type: release-dispatch
+        client-payload: '{"version": "${{ steps.event.outputs.version }}"}'
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [dispatch]
+    if: ${{ always() && needs.dispatch.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure"
+        comment_if_exists: true
+        issue_title: "Failure: Send Compat Stack Dispatch"
+        issue_body: |
+          Compat stack dispatch workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+           Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ compat:
 		--build-arg packages="`cat "packages/cflinuxfs4-compat" 2>/dev/null`" \
   	--no-cache "--iidfile=$(COMPAT_BUILD).iid"
 
-	docker run "--cidfile=$(COMPAT_BUILD).cid" `cat "$(COMPAT_BUILD).iid"` dpkg -l | tee "packages-list"
+	docker run "--cidfile=$(COMPAT_BUILD).cid" `cat "$(COMPAT_BUILD).iid"` dpkg -l
 	docker export `cat "$(COMPAT_BUILD).cid"` | gzip > "$(COMPAT_BUILD).tar.gz"
 	docker rm -f `cat "$(COMPAT_BUILD).cid"`
 	rm -f "$(COMPAT_BUILD).cid" "$(COMPAT_BUILD).iid"

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ARCH := x86_64
 NAME := cflinuxfs4
 BASE := ubuntu:jammy
 BUILD := $(NAME).$(ARCH)
+COMPAT_BUILD := $(NAME)-compat.$(ARCH)
 
 all: $(BUILD).tar.gz
 
@@ -11,12 +12,12 @@ compat:
 		--file compat.Dockerfile \
 		--build-arg "base=cloudfoundry/cflinuxfs4:$(version)" \
 		--build-arg packages="`cat "packages/cflinuxfs4-compat" 2>/dev/null`" \
-  	--no-cache "--iidfile=$(BUILD)-compat.iid"
+  	--no-cache "--iidfile=$(COMPAT_BUILD).iid"
 
-	docker run "--cidfile=$(BUILD)-compat.cid" `cat "$(BUILD)-compat.iid"` dpkg -l | tee "packages-list"
-	docker export `cat "$(BUILD)-compat.cid"` | gzip > "$(BUILD)-compat.tar.gz"
-	docker rm -f `cat "$(BUILD)-compat.cid"`
-	rm -f "$(BUILD)-compat.cid" "$(BUILD)-compat.iid"
+	docker run "--cidfile=$(COMPAT_BUILD).cid" `cat "$(COMPAT_BUILD).iid"` dpkg -l | tee "packages-list"
+	docker export `cat "$(COMPAT_BUILD).cid"` | gzip > "$(COMPAT_BUILD).tar.gz"
+	docker rm -f `cat "$(COMPAT_BUILD).cid"`
+	rm -f "$(COMPAT_BUILD).cid" "$(COMPAT_BUILD).iid"
 
 $(BUILD).iid:
 	docker build \

--- a/compat.Dockerfile
+++ b/compat.Dockerfile
@@ -1,0 +1,10 @@
+ARG base
+FROM ${base}
+
+ARG packages
+ARG package_args='--allow-downgrades --allow-remove-essential --allow-change-held-packages --no-install-recommends'
+
+RUN  apt-get -y $package_args update && \
+  apt-get -y $package_args install $packages && \
+  apt-get clean && \
+  find /usr/share/doc/*/* ! -name copyright | xargs rm -rf

--- a/packages/cflinuxfs4-compat
+++ b/packages/cflinuxfs4-compat
@@ -1,0 +1,8 @@
+bzr
+dh-python
+libjson-glib-1.0-0
+libmagickwand-dev
+libpango1.0-0
+mercurial
+ruby
+ubuntu-minimal


### PR DESCRIPTION
Add makefile target and dockerfile for the cflinuxfs-compat-release use-case. 
When running `make compat version <version>`, a docker build will run with the compat.Dockerfile which uses `cloudfoundry/cflinuxfs4:<version>` as its base image, and installs the set of packages that we removed in https://github.com/cloudfoundry/cflinuxfs4/pull/2 and https://github.com/cloudfoundry/cflinuxfs4/pull/3, and outputs a rootfs tarball for the compat stack