### PR TITLE
Allow user-set openssl configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,9 @@ RUN useradd -u ${user_id} -mU -s /bin/bash vcap && \
   chown vcap:vcap /home/vcap/app && \
   ln -s /home/vcap/app /app
 
+RUN printf '\n%s\n' >> "/etc/ssl/openssl.cnf" \
+  '# Allow user-set openssl.cnf' \
+  '.include /tmp/app/openssl.cnf' \
+  '.include /home/vcap/app/openssl.cnf'
+
 USER ${user_id}:${group_id}


### PR DESCRIPTION
We recently encountered an issue in the .NET Core buildpack (related to https://github.com/dotnet/runtime/issues/67353) in which due to an out-of-date `gss-ntlm` package in Ubuntu 22.04, certain NTLM-related behaviour fails because it is not compatible with Openssl 3. The workaround (unless Canonical upgrades gss-ntlm) involves modifying the `openssl.cnf` file to rollback Openssl provider settings.

We have seen other instances where a user being able to modify the Openssl configuration would be useful: https://github.com/cloudfoundry/dotnet-core-buildpack/issues/567

This PR adds an `include` path to the `openssl.cnf` file so that users can provide their own `openssl.cnf` file in their application directory to modify openssl settings