### PR TITLE
ping: allow run as setuid-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,7 @@ RUN printf '\n%s\n' >> "/etc/ssl/openssl.cnf" \
   '.include /tmp/app/openssl.cnf' \
   '.include /home/vcap/app/openssl.cnf'
 
+# Without setuid, ping fails in a CF app container
+RUN chmod u+s /usr/bin/ping
+
 USER ${user_id}:${group_id}


### PR DESCRIPTION
The iputils-ping version present in the cflinuxfs4 stack does not have the setuid bit set (like that one in cflinuxfs3). The installer checks for LIBCAP[1], and if available sets file capability cap_net_raw+p and do not set the setuid bit - this is happening in our case. However, when ping is run in the CF application container created by garden (vcap user), it fails with "operation not permitted" error. Setuid-rooting works around this.

Tested out by deploying a bosh release and running ping from cf-sshing into the app container.

### More details

tldr: The real root cause is still undetermined.

The following runs fine:
```
$ docker run --user vcap:vcap cloudfoundry/cflinuxfs4 sh -c "ping www.cloudfoundry.org -w1"
```

and you can see the file capabilities of ping
```
$ docker run --user vcap:vcap cloudfoundry/cflinuxfs4 sh -c "getcap /usr/bin/ping"
/usr/bin/ping cap_net_raw=ep
```

but when you run it vai `cf ssh cflinuxfs4-app`:
```
$ /usr/sbin/getcap $(command -v ping)
<no response>
```

The ping program is capabilities aware - it explicitly adds and removes capabilities/effective bit in code ([link](https://github.com/iputils/iputils/blob/8d1acb6d95731ce1b2c7ee1c361bccfaa0918487/ping/ping.c#L585-L614)). This would error if it does not have the permission to gain that desired capability.

On a discussion thread with the Garden team ([link](https://cloudfoundry.slack.com/archives/C033RE5D6/p1694113339696739)), they believe the container should have CAP_NET_RAW, and the possible culpurit could be another undetermined system setting.

It's also possible that since file capabilities are stored as xattr attributes ([man](https://man7.org/linux/man-pages/man7/capabilities.7.html)), and the docker image is "docker-exported" to make it into a bosh-release blob, the export doesn't preserve the attributes!!

1. https://github.com/iputils/iputils/blob/8d1acb6d95731ce1b2c7ee1c361bccfaa0918487/meson.build#L161-L168