### PR TITLE
Revert "ping: allow run as setuid-root"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,4 @@ RUN printf '\n%s\n' >> "/etc/ssl/openssl.cnf" \
   '.include /tmp/app/openssl.cnf' \
   '.include /home/vcap/app/openssl.cnf'
 
-# Without setuid, ping fails in a CF app container
-RUN chmod u+s /usr/bin/ping
-
 USER ${user_id}:${group_id}


### PR DESCRIPTION
This reverts https://github.com/cloudfoundry/cflinuxfs4/pull/13
The reverted workaround is not needed anymore as the underlying issue has been found.
See https://github.com/cloudfoundry/cflinuxfs4-release/pull/5 for details.

This PR is dependent on merging the above mentioned bosh-release PR.