### PR TITLE
Use local image for cflinuxfs4 compat release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,14 @@ all: $(BUILD).tar.gz
 
 compat:
 	if [ -z "$(version)" ]; then >&2 echo "version must be set" && exit 1; fi
+
+	curl --fail -L -o cflinuxfs4.tar.gz https://github.com/cloudfoundry/cflinuxfs4/releases/download/v$(version)/cflinuxfs4-$(version).tar.gz
+	gunzip -c cflinuxfs4.tar.gz | docker import - cflinuxfs4-local:$(version)
+	rm -f cflinuxfs4.tar.gz
+
 	docker build . \
 		--file compat.Dockerfile \
-		--build-arg "base=cloudfoundry/cflinuxfs4:$(version)" \
+		--build-arg "base=cflinuxfs4-local:$(version)" \
 		--build-arg packages="`cat "packages/cflinuxfs4-compat" 2>/dev/null`" \
   	--no-cache "--iidfile=$(COMPAT_BUILD).iid"
 


### PR DESCRIPTION
## Issue
The cflinuxfs4 image is no longer uploaded to docker hub so the compat target in the makefile fails

## Proposed Change
Fetch the image from the cflinuxfs4 GH release, import it in docker locally and then use it as base for the compat build.